### PR TITLE
Add dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,6 +1,8 @@
 name: Dependency Submission
 on:
   workflow_call:
+permissions:
+  contents: write
 jobs:
   dependency-submission:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,6 +1,10 @@
 name: Dependency Submission
 on:
   workflow_call:
+    secrets:
+      ssh_private_key:
+        required: true
+
 permissions:
   contents: write
 jobs:
@@ -11,6 +15,6 @@ jobs:
       uses: interact-io/github-actions/actions/setup-java-gradle@master
       with:
         submodules: 'true'
-        ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+        ssh-key: ${{ secrets.ssh_private_key }}
     - name: Generate and submit dependency graph
       uses: gradle/actions/dependency-submission@v6

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,14 @@
+name: Dependency Submission
+on:
+  workflow_call:
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Java with Gradle
+      uses: interact-io/github-actions/actions/setup-java-gradle@master
+      with:
+        submodules: 'true'
+        ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@v6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an on-demand "Dependency Submission" workflow to automate Gradle dependency graph generation and submission. It provisions a Java/Gradle build environment, runs dependency graph generation, and submits results. The workflow runs via on-demand invocation and requires repository credentials and write permission to perform the submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->