### PR TITLE
Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    reviewers:
++      - "plevie"
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     reviewers:
-+      - "plevie"
+      - "plevie"
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured automated updates for CI/workflow dependencies to run weekly, limit concurrent update PRs to 5, and automatically label dependency update PRs for easier tracking and review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->